### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - 0.10
   - 0.12
+  - 8.11.4
 
 before_script:
   - npm install -g grunt-cli

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "require-clean",
   "description": "Cleanly `require` a module from disk, having flushed the module's cache, including all of its submodules. Used like normal `require`",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "homepage": "http://github.com/anodynos/require-clean/",
   "author": {
     "name": "Agelos Pikoulas",

--- a/package.json
+++ b/package.json
@@ -45,14 +45,14 @@
     "resolve-from": "^4.0.0"
   },
   "devDependencies": {
-    "chai": "4.1.2",
-    "grunt": "^1.0.3",
-    "grunt-contrib-watch": "~1.1.x",
-    "grunt-urequire": "~0.7.3",
-    "mocha": "5.2.x",
-    "uberscore": "0.0.19",
-    "urequire": ">=0.7.0-beta.33",
-    "urequire-ab-specrunner": "~0.2.6",
-    "urequire-rc-inject-version": "~0.1.6"
+    "mocha": "2.0.x",
+    "chai": "1.9.2",
+    "grunt": "~0.4.5",
+    "grunt-contrib-watch": "~0.5.x",
+    "grunt-urequire": "~0.7.2",
+    "urequire": ">=0.7.0-beta.21",
+    "uberscore": "0.0.16",
+    "urequire-ab-specrunner": "~0.2.1",
+    "urequire-rc-inject-version": "~0.1.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,22 +37,22 @@
     "dist": "./build"
   },
   "engines": {
-    "node": ">=0.10.x"    
+    "node": ">=0.10.x"
   },
   "dependencies": {
-    "caller-path": "^0.1.0",
-    "lodash": "3.x",
-    "resolve-from": "^1.0.0"
+    "caller-path": "^2.0.0",
+    "lodash": "4.x",
+    "resolve-from": "^4.0.0"
   },
   "devDependencies": {
-    "mocha": "2.0.x",
-    "chai": "1.9.2",
-    "grunt": "~0.4.5",
-    "grunt-contrib-watch": "~0.5.x",
-    "grunt-urequire": "~0.7.2",
-    "urequire": ">=0.7.0-beta.21",
-    "uberscore": "0.0.16",
-    "urequire-ab-specrunner": "~0.2.1",
-    "urequire-rc-inject-version": "~0.1.5"
+    "chai": "4.1.2",
+    "grunt": "^1.0.3",
+    "grunt-contrib-watch": "~1.1.x",
+    "grunt-urequire": "~0.7.3",
+    "mocha": "5.2.x",
+    "uberscore": "0.0.19",
+    "urequire": ">=0.7.0-beta.33",
+    "urequire-ab-specrunner": "~0.2.6",
+    "urequire-rc-inject-version": "~0.1.6"
   }
 }


### PR DESCRIPTION
Updated dependencies because of known security issues with lodash, moment, minimatch and qs.
See https://nodesecurity.io/advisories/577.